### PR TITLE
Remove os choice & change file choose method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_store
 
 # Ignore node_modules folder
-Scenarios
+# Scenarios
 shiny_bookmarks
 
 # Ignore files related to API keys

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .DS_store
 
 # Ignore node_modules folder
-# Scenarios
+Scenarios
 shiny_bookmarks
 
 # Ignore files related to API keys

--- a/Functions.r
+++ b/Functions.r
@@ -8,34 +8,20 @@ VBGF.age<-function(Linf,k,t0,lt){
   } 
   
 
-RUN.SS<-function(path,ss.cmd=" -nohess -nox",OS.in="Windows"){ 
-  navigate <- paste("cd ", path, sep="") 
-if(OS.in=="Windows") 
-  {
-    #command <- paste0(navigate," & ", "ss", ss.cmd) 
-    #shell(command, invisible=TRUE, translate=TRUE)
-    r4ss::run(path,exe="ss3",extras=ss.cmd,skipfinished=FALSE,show_in_console = TRUE)
-  } 
-if(OS.in=="Mac" && R.version[["arch"]]=="x86_64")  
-  {
-    
-    command <- c(paste("cd", path), "chmod +x ./ss3_osx",paste("./ss3_osx", ss.cmd)) 
+RUN.SS<-function(path,ss.cmd=" -nohess -nox"){ 
+  navigate <- paste("cd ", path, sep="")
+  if(.Platform[["OS.type"]] == "windows"){os_exe <- "ss3"} 
+  if(substr(R.version[["os"]], 1, 6) == "darwin" && R.version[["arch"]]=="x86_64"){os_exe <- "ss3_osx"} 
+  if(substr(R.version[["os"]], 1, 6) == "darwin" && R.version[["arch"]]=="aarch64"){os_exe <- "ss3_osx_arm64"} 
+  if(R.version[["os"]] == "linux-gnu"){os_exe <- "ss3_linux"}
+  
+  if(os_exe=="ss3") 
+    {
+      r4ss::run(path,exe=os_exe,extras=ss.cmd,skipfinished=FALSE,show_in_console = TRUE)
+    } else {
+    command <- c(paste("cd", path), paste0("chmod +x ./", os_exe), paste0("./", os_exe, " ", ss.cmd)) 
     system(paste(command, collapse=";"),invisible=TRUE)
-    
-    #command <- paste0(path,"/./ss_mac", ss.cmd) 
-    #system(command, invisible=TRUE)
-  } 
-if(OS.in=="Mac" && R.version[["arch"]]=="aarch64")  
-  {
-    
-    command <- c(paste("cd", path), "chmod +x ./ss3_osx_arm64",paste("./ss3_osx_arm64", ss.cmd)) 
-    system(paste(command, collapse=";"),invisible=TRUE)
-  } 
-if(OS.in=="Linux") 
-  {
-    command <- c(paste("cd", path), "chmod +x ./ss3_linux",paste("./ss3_linux", ss.cmd)) 
-    system(paste(command, collapse=";"), invisible=TRUE)
-  }   
+    }
 }  
 
 pngfun <- function(wd, file,w=7,h=7,pt=12){

--- a/server.r
+++ b/server.r
@@ -75,7 +75,7 @@ shinyServer(function(input, output,session) {
   rv.AgeErr <- reactiveValues(data = NULL,clear = FALSE)
   
   
-  volumes <- c(wd='.',getVolumes()())
+  volumes <- c(wd='.', parentdir='..', getVolumes()())
   
   # Choose bookmarked inputs
   shinyFileChoose(input, id = 'loadInputs', root=volumes, filetypes=c('', 'rds'))
@@ -5370,7 +5370,7 @@ if(length(grep("end_logit",rownames(Model.output$parameters)))>0)
 ### Likelihood profiles, Sensitivities, and Ensemble models ###
 ###############################################################
 
-  roots <- getVolumes()()  
+  roots <- c(wd='.', parentdir='..', getVolumes()()) 
 
 
   #CODE TO ALLOW USERS TO SAVE OUTPUT SOMEWHERE OTHER THAN SCENARIOS FOLDER 

--- a/server.r
+++ b/server.r
@@ -119,6 +119,7 @@ saveInputs <- function(input, bookmarkPath, bookmarkURL, session){
   dir_delete(bookmarkPath) #delete bookmark created from session$doBookmark as we are just using it to create the query string and grab the filepath
 }
 
+
 ########## Clear data files and plots ############
   rv.Lt <- reactiveValues(data = NULL,clear = FALSE)
   rv.Age <- reactiveValues(data = NULL,clear = FALSE)
@@ -278,8 +279,8 @@ observeEvent(req(any(!is.null(rv.Ct$data),!is.null(rv.Lt$data),!is.null(rv.Age$d
   #     shinyjs::reset('file2')
   # })
 
-#####################################################
 
+#####################################################
 onclick("est_LHparms",id="panel_SS_est")
 
 
@@ -4814,13 +4815,13 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
     if(is.null(input$no_hess)){
       cmd.in<-""
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
 
       if(!file.exists(paste0("Scenarios/",input$Scenario_name,"data_echo.ss_new")))
         {
       cmd.in<-" -nohess"
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
         }
     }
 
@@ -4830,13 +4831,13 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
       {
       cmd.in<-" -nohess"
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
       }
       if(!input$no_hess)
       {
       cmd.in<-""
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
       }
     }
     }
@@ -4850,13 +4851,13 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
     if(is.null(input$no_hess)){
       cmd.in<-""
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
 
       if(!file.exists(paste0("Scenarios/",input$Scenario_name,"data_echo.ss_new")))
         {
       cmd.in<-" -nohess"
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
         }
     }
 
@@ -4866,13 +4867,13 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
       {
       cmd.in<-" -nohess"
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
       }
       if(!input$no_hess)
       {
       cmd.in<-""
       if(!is.null(input$add_comms)){if(input$add_comms==TRUE){cmd.in=paste0(" -nohess ",input$add_comms_in)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
       }
     }
   }
@@ -4882,13 +4883,13 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
     if(is.null(input$no_hess_user)){
       cmd.in<-""
       if(!is.null(input$add_comms_user)){if(input$add_comms_user==TRUE){cmd.in=paste0(" ",input$add_comms_in_user)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
 
       if(!file.exists(paste0("Scenarios/",input$Scenario_name,"data_echo.ss_new")))
         {
       cmd.in<-" -nohess"
       if(!is.null(input$add_comms_user)){if(input$add_comms_user==TRUE){cmd.in=paste0(" ",input$add_comms_in_user)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
         }
     }
 
@@ -4898,13 +4899,13 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
       {
       cmd.in<-" -nohess"
       if(!is.null(input$add_comms_user)){if(input$add_comms_user==TRUE){cmd.in=paste0(" ",input$add_comms_in_user)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
       }
       if(!input$no_hess_user)
       {
       cmd.in<-""
       if(!is.null(input$add_comms_user)){if(input$add_comms_user==TRUE){cmd.in=paste0(" ",input$add_comms_in_user)}}
-      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in,OS.in=input$OS_choice)
+      RUN.SS(paste0("Scenarios/",input$Scenario_name),ss.cmd=cmd.in)
       }
     }
   }
@@ -4986,10 +4987,10 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
     }
     
   #Run multiple jitters
-    if(input$OS_choice=="Windows"){os_exe <- "ss3"} 
-    if(input$OS_choice=="Mac" && R.version[["arch"]]=="x86_64"){os_exe <- "ss3_osx"}
-    if(input$OS_choice=="Mac" && R.version[["arch"]]=="aarch64"){os_exe <- "ss3_osx_arm64"}
-    if(input$OS_choice=="Linux"){os_exe <- "ss3_linux"}
+    if(.Platform[["OS.type"]] == "windows"){os_exe <- "ss3"} 
+    if(substr(R.version[["os"]], 1, 6) == "darwin" && R.version[["arch"]]=="x86_64"){os_exe <- "ss3_osx"} 
+    if(substr(R.version[["os"]], 1, 6) == "darwin" && R.version[["arch"]]=="aarch64"){os_exe <- "ss3_osx_arm64"} 
+    if(R.version[["os"]] == "linux-gnu"){os_exe <- "ss3_linux"}
       
     if(input$jitter_choice)
     {
@@ -5076,7 +5077,7 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
              starter.file$init_values_src<-1
              starter.file$jitter_fraction<-0
          SS_writestarter(starter.file,paste0(main.dir,"/Scenarios/",input$Scenario_name),overwrite=TRUE)
-         RUN.SS(paste0(main.dir,"/Scenarios/",input$Scenario_name),ss.cmd="",OS.in=input$OS_choice)
+         RUN.SS(paste0(main.dir,"/Scenarios/",input$Scenario_name),ss.cmd="")
          Model.output<-try(SS_output(paste0(main.dir,"/Scenarios/",input$Scenario_name),verbose=FALSE,printstats = FALSE))
           if(class(Model.output)=="try-error")
           {
@@ -5368,7 +5369,7 @@ if(dir.exists(file.path(modeff.dir,modeff.name))==FALSE)
 if(input$Opt_mod==TRUE)
 {
   show_modal_spinner(spin="flower",color=wes_palettes$Rushmore[1],text=paste0("Run initial optimization?"))
-  RUN.SS(file.path(modeff.dir,modeff.name),ss.cmd="-nox -mcmc 100 -hbf",OS.in=input$OS_choice)
+  RUN.SS(file.path(modeff.dir,modeff.name),ss.cmd="-nox -mcmc 100 -hbf")
 
   remove_modal_spinner()
 }

--- a/ui.r
+++ b/ui.r
@@ -28,58 +28,79 @@ shinyjs::hidden(wellPanel(id="Bookmark_panel",
           h4(strong("Upload bookmarked inputs")),
           fluidRow(
             column(12, h4("Upload a saved input rds file:")),
-            column(12, fileInput("loadInputs", NULL)),
-            column(12, h6("File namess should only inlcude letters and numbers, otherwise an upload error may occur. If you see 'Error: Invalid state id', rename the file and try again."))
+            # column(12, fileInput("loadInputs", NULL)),
+            column(12, shinyFilesButton("loadInputs", label = "Input file", title = "Input file", multiple = FALSE)),
+            column(12, h6("File names should only inlcude letters and numbers, otherwise an upload error may occur. If you see 'Error: Invalid state id', rename the file and try again."))
           ))),
 
 shinyjs::hidden(wellPanel(id="Data_panel",
                           h4(strong("Choose data file")),
-                          fluidRow(column(width=12,fileInput('file2', 'Catch time series',
-                                                             accept = c(
-                                                               'text/csv',
-                                                               'text/comma-separated-values',
-                                                               'text/tab-separated-values',
-                                                               'text/plain',
-                                                               '.csv'
-                                                             )
-                          ))),
-                          
-                          fluidRow(column(width=12,fileInput('file1', 'Length composition',
-                                                             accept = c(
-                                                               'text/csv',
-                                                               'text/comma-separated-values',
-                                                               'text/tab-separated-values',
-                                                               'text/plain',
-                                                               '.csv'
-                                                             )
-                          ))),
-                          
-                          fluidRow(column(width=12,fileInput('file3', 'Age composition',
-                                                             accept = c(
-                                                               'text/csv',
-                                                               'text/comma-separated-values',
-                                                               'text/tab-separated-values',
-                                                               'text/plain',
-                                                               '.csv'
-                                                             )
-                          ))),
-                          
-                          
+                          fluidRow(column(width=12, shinyFilesButton('file2',
+                                                                     label="Catch time series",
+                                                                     title="Catch time series", multiple=FALSE))),
+                          verbatimTextOutput("catch_filename"),
+                          fluidRow(column(width=12, shinyFilesButton('file1',
+                                                                     label="Length composition",
+                                                                     title="Length composition", multiple=FALSE))),
+                          verbatimTextOutput("length_filename"),
+                          fluidRow(column(width=12, shinyFilesButton('file3',
+                                                                     label="Age composition",
+                                                                     title="Age composition", multiple=FALSE))),
+                          verbatimTextOutput("age_filename"),
+                          fluidRow(column(width=12, shinyFilesButton('file4',
+                                                                     label="Abundance index",
+                                                                     title="Abundance index", multiple=FALSE))),
+                          verbatimTextOutput("index_filename"),
+                          # fluidRow(column(width=12, shinyFilesButton('file3', 
+                          #                                            label="Age composition", 
+                          #                                            title="Choose age composition file", multiple=FALSE))),
+                          # verbatimTextOutput("ageFile"),
+                          # fluidRow(column(width=12, shinyFilesButton('file4', 
+                          #                                            label="Abundance index", 
+                          #                                            title="Choose abundance index file", multiple=FALSE))),
+                          # verbatimTextOutput("abundancFile"),
+                          # fluidRow(column(width=12,fileInput('file2', 'Catch time series',
+                          #                                    accept = c(
+                          #                                      'text/csv',
+                          #                                      'text/comma-separated-values',
+                          #                                      'text/tab-separated-values',
+                          #                                      'text/plain',
+                          #                                      '.csv'
+                          #                                    )
+                          # ))),
+                          # fluidRow(column(width=12,fileInput('file1', 'Length composition',
+                          #                                    accept = c(
+                          #                                      'text/csv',
+                          #                                      'text/comma-separated-values',
+                          #                                      'text/tab-separated-values',
+                          #                                      'text/plain',
+                          #                                      '.csv'
+                          #                                    )
+                          # ))),
+                          # fluidRow(column(width=12,fileInput('file3', 'Age composition',
+                          #                                    accept = c(
+                          #                                      'text/csv',
+                          #                                      'text/comma-separated-values',
+                          #                                      'text/tab-separated-values',
+                          #                                      'text/plain',
+                          #                                      '.csv'
+                          #                                    )
+                          # ))),
                           #Mute for now, pull back in when index methods are ready
-                          fileInput('file4', 'Abundance index',
-                                    accept = c(
-                                      'text/csv',
-                                      'text/comma-separated-values',
-                                      'text/tab-separated-values',
-                                      'text/plain',
-                                      '.csv'
-                                    )
-                          ),
+                          # fileInput('file4', 'Abundance index',
+                          #           accept = c(
+                          #             'text/csv',
+                          #             'text/comma-separated-values',
+                          #             'text/tab-separated-values',
+                          #             'text/plain',
+                          #             '.csv'
+                          #           )
+                          # ),
                           h4(strong("Clear data files")),
                              fluidRow(column(width=3,actionButton("reset_ct", "Catches")),
                                       column(width=3,actionButton("reset_lt", "Length")),
                                       column(width=3,actionButton("reset_age", "Ages")),
-                                      column(width=3,actionButton("reset_index", "Index"))), 
+                                      column(width=3,actionButton("reset_index", "Index"))),
                         )
                       ),
 
@@ -737,7 +758,7 @@ shinyjs::hidden(wellPanel(id="panel_SS_LH_fixed_est_tog",
   
       #popify(uiOutput("AdvancedSS_Sex3"),"Sex=3 option for lengths","This switch changes the per sex length compositions (sex = 1 for females and 2 for males) into a two sex length composition that retains the overall length composition of the sample. This may add additional information on the underlying sex ratio of the population, but should be tested against using the length compositions by sex."),
       #popify(uiOutput("AdvancedSS_AgeSex3"),"Sex=3 option for ages","This switch changes the per sex age compositions (sex = 1 for females and 2 for males) into a two sex length composition that retains the overall length composition of the sample. This may add additional information on the underlying sex ratio of the population, but should be tested against using the age compositions by sex."),
-      popify(uiOutput("AdvancedSS_ageerror"),"Ageing error matrices.","Add as many custom ageing error matrices as needed. See the folders Example data files --> ageing error matrices for examples of the ageing error input."),
+      popify(uiOutput("AdvancedSS_ageerror")," error matrices.","Add as many custom ageing error matrices as needed. See the folders Example data files --> ageing error matrices for examples of the ageing error input."),
       uiOutput("AdvancedSS_ageerror_in"),
       fluidRow(style = "padding-right:50px;padding-left:50px;padding-top:-1000px; padding-bottom:0px;",h6("Software to calculate ageing error matrices from multiple age reads is available ",tags$a(href="https://github.com/pfmc-assessments/nwfscAgeingError", "here", target="_blank"),".")),
       #uiOutput("AdvancedSS_retro_choice"),

--- a/ui.r
+++ b/ui.r
@@ -23,6 +23,7 @@ shinyUI(fluidPage(theme = "bootstrap.css",
 sidebarLayout(
    sidebarPanel(
     style = "position:fixed;width:30%;height: 90vh; overflow-y: scroll;",
+    
 shinyjs::hidden(wellPanel(id="Bookmark_panel",
           h4(strong("Upload bookmarked inputs")),
           fluidRow(
@@ -32,18 +33,40 @@ shinyjs::hidden(wellPanel(id="Bookmark_panel",
           ))),
 
 shinyjs::hidden(wellPanel(id="Data_panel",
-  h4(strong("Choose data file")),
- fluidRow(column(width=12,fileInput('file2', 'Catch time series',
-                           accept = c(
-                             'text/csv',
-                             'text/comma-separated-values',
-                             'text/tab-separated-values',
-                             'text/plain',
-                             '.csv'
-                           )
-  ))),
- 
-  fluidRow(column(width=12,fileInput('file1', 'Length composition',
+                          h4(strong("Choose data file")),
+                          fluidRow(column(width=12,fileInput('file2', 'Catch time series',
+                                                             accept = c(
+                                                               'text/csv',
+                                                               'text/comma-separated-values',
+                                                               'text/tab-separated-values',
+                                                               'text/plain',
+                                                               '.csv'
+                                                             )
+                          ))),
+                          
+                          fluidRow(column(width=12,fileInput('file1', 'Length composition',
+                                                             accept = c(
+                                                               'text/csv',
+                                                               'text/comma-separated-values',
+                                                               'text/tab-separated-values',
+                                                               'text/plain',
+                                                               '.csv'
+                                                             )
+                          ))),
+                          
+                          fluidRow(column(width=12,fileInput('file3', 'Age composition',
+                                                             accept = c(
+                                                               'text/csv',
+                                                               'text/comma-separated-values',
+                                                               'text/tab-separated-values',
+                                                               'text/plain',
+                                                               '.csv'
+                                                             )
+                          ))),
+                          
+                          
+                          #Mute for now, pull back in when index methods are ready
+                          fileInput('file4', 'Abundance index',
                                     accept = c(
                                       'text/csv',
                                       'text/comma-separated-values',
@@ -51,37 +74,14 @@ shinyjs::hidden(wellPanel(id="Data_panel",
                                       'text/plain',
                                       '.csv'
                                     )
-  ))),
- 
-  fluidRow(column(width=12,fileInput('file3', 'Age composition',
-            accept = c(
-              'text/csv',
-              'text/comma-separated-values',
-              'text/tab-separated-values',
-              'text/plain',
-              '.csv'
-            )
-          ))),
-
- 
-  #Mute for now, pull back in when index methods are ready
-  fileInput('file4', 'Abundance index',
-            accept = c(
-              'text/csv',
-              'text/comma-separated-values',
-              'text/tab-separated-values',
-              'text/plain',
-              '.csv'
-            )
-          ),
- 
-  h4(strong("Clear data files")),
-     fluidRow(column(width=3,actionButton("reset_ct", "Catches")),
-              column(width=3,actionButton("reset_lt", "Length")),
-              column(width=3,actionButton("reset_age", "Ages")),
-              column(width=3,actionButton("reset_index", "Index"))), 
-)
-),
+                          ),
+                          h4(strong("Clear data files")),
+                             fluidRow(column(width=3,actionButton("reset_ct", "Catches")),
+                                      column(width=3,actionButton("reset_lt", "Length")),
+                                      column(width=3,actionButton("reset_age", "Ages")),
+                                      column(width=3,actionButton("reset_index", "Index"))), 
+                        )
+                      ),
 
 shinyjs::hidden(wellPanel(id="Existing_files",
  fluidRow(column(width=10,checkboxInput("user_model","Use existing model files?",FALSE))),
@@ -812,13 +812,13 @@ shinyjs::hidden(wellPanel(id="panel_SS_LH_fixed_est_tog",
         ),
 
     #wellPanel(
-    shinyjs::hidden(awesomeRadio(
-      inputId = "OS_choice",
-      label = "Which OS?", 
-      choices = c("Windows","Mac","Linux"),
-      selected = "Windows",
-      inline=TRUE,
-      status = "warning")),
+    # shinyjs::hidden(awesomeRadio(
+    #   inputId = "OS_choice",
+    #   label = "Which OS?", 
+    #   choices = c("Windows","Mac","Linux"),
+    #   selected = "Windows",
+    #   inline=TRUE,
+    #   status = "warning")),
     #), 
 
     shinyjs::hidden(wellPanel(id="Scenario_panel",


### PR DESCRIPTION
1. Remove the operating system choice; have the app detect the OS and use the right exe.
2. The previous fileInput() method had limitations when it came to using the SAC tool through [a docker container that I created](https://github.com/e-perl-NOAA/SAC-docker/tree/main) (this container can be run in Codespaces too) which was that the app couldn't find/use files within the container, it could only find/use files on your local machine. After quite a bit of research (exploring the depths of Google), the solution to that is to use shinyFilesButton() and shinyFileChoose() (similar to shinyDirButton() and shinyDirChoose() that you used in other diagnostic tabs of the app) which allows you to get access to local and remote "volumes". This is probably a limited understanding of what it does on my part, but in practice it allows users access to files inside a container *and* files on a local machine. Special shout out to Brian Snouffer for helping me with a small error that popped up when I initially started implementing shinyFilesButton() and shinyFileChoose().