### PR TITLE
Fix model output time series table because of ss3 changes

### DIFF
--- a/server.r
+++ b/server.r
@@ -5277,16 +5277,21 @@ SS_writeforecast(forecast.file,paste0("Scenarios/",input$Scenario_name),overwrit
  			})
 		#Time series output
  		output$SSout_table <- render_gt({
-        Output_table<-Model.output$sprseries[,c(1,3,4,23,24,7,8,9,10,12,13,25,53,54)]
+ 		    Output_table <- Model.output$sprseries |>
+ 		      dplyr::select(Yr, `SSBfished/R`, SPR, YPR) |>
+ 		      dplyr::left_join(Model.output$annual_time_series, by = c("Yr" = "year")) |>
+ 		      dplyr::select(Yr, Bio_all_an, Bio_Smry_an, SSB, recruits, `SSBfished/R`, SPR, SPR_std, YPR, Depletion_std, F_std, tot_exploit, sum_fleet_F,`F=Z-M`)
+ 		  
         Output_table<-mutate_if(Output_table,is.numeric, round, 2)  
-       gt(Output_table)%>%
+        
+       gt(Output_table) |>
         tab_header(
         title = "Time Series of Derived Model Outputs",
         subtitle = ""
-        ) %>%
-        data_color(columns = c(4,7,10,12), method = "auto", palette = "viridis",reverse=TRUE) %>%
+        ) |>
+        data_color(columns = c(4,7,10,12), method = "auto", palette = "viridis", reverse=TRUE) |>
         tab_style(style = list(cell_text(weight = "bold")),
-                locations = cells_body(columns = c(Deplete))) %>%
+                locations = cells_body(columns = c(Depletion_std))) |>
         opt_interactive(use_search = TRUE,
                       use_highlight = TRUE,
                       use_page_size_select = TRUE)


### PR DESCRIPTION
I was doing some testing after updating the model input files that the SAC tool uses in each scenarios (running the model and then replacing those input files with the .ss_new files) and while looking through the Model output tab I saw that there is an error (pictured below).

<img width="925" alt="SS-DL-tool_issue" src="https://github.com/user-attachments/assets/25d7e810-7b88-455e-8adc-cea17c934989" />  

It is coming from the following lines: https://github.com/shcaba/SS-DL-tool/blob/32b37c2fb89cc73646e6015acec867fe45b45d6b/server.r#L5279-L5293

This is happening because the sprseries has been changed so that only some of that info is in the sprseries and the rest of it is in the annual_time_series table (see r4ss commit https://github.com/r4ss/r4ss/commit/d8ef177d4a6942fc195af7c1f834856c80a4a3fb and ss3-source code commit https://github.com/nmfs-ost/ss3-source-code/commit/b192b1b7c469e0118eabe2e533f9ebcff9b91787 that deal with this change). 

I combined those two tables (sprseries and annual_time_series) to get the values that used to be there back out, though some of those columns have slightly different names now (which could always be renamed to something more user-friendly if you would like!). I used the native pipe in this portion mostly because that seems to be a best practice that the R community is going towards instead of the other pipe.

I still need to double-check with Rick that sum_fleet_F is indeed the right replacement for the apical_F column (Ian and I are pretty sure that it is) before you merge this PR and I will post a comment to the PR once I get Rick's response (probably on Monday) that it is ready to merge if you are okay with the changes.
